### PR TITLE
feat: Update website copy and remove phone number

### DIFF
--- a/src/components/BOFUSection.tsx
+++ b/src/components/BOFUSection.tsx
@@ -10,24 +10,22 @@ interface BOFUSectionProps {
 
 const content = {
   de: {
-    title: "Bereit für den nächsten Schritt?",
-    subtitle: "Sichere dir jetzt dein kostenloses Erstgespräch und erfahre, wie auch du diesen Skill lernen kannst.",
+    title: "Bereit für den ersten Schritt?",
+    subtitle: "👉 Sichere dir jetzt ein kostenloses Erstgespräch.\n👉 15 Minuten, die dir Klarheit geben können.\n👉 100 % unverbindlich.",
     cta: {
-      A: "Kostenloses Gespräch sichern",
-      B: "Jetzt kostenlos starten"
+      A: "Sichere dir jetzt ein kostenloses Erstgespräch",
+      B: "Sichere dir jetzt ein kostenloses Erstgespräch"
     },
-    calendar: "📅 Verfügbare Termine anzeigen",
-    urgency: "⏰ Nur noch wenige Plätze für diese Woche verfügbar"
+    calendar: "📅 Hier Termin auswählen"
   },
   en: {
-    title: "Ready for the next step?",
-    subtitle: "Secure your free initial consultation now and find out how you too can learn this skill.",
+    title: "Ready for the first step?",
+    subtitle: "👉 Secure your free initial consultation now.\n👉 15 minutes that can give you clarity.\n👉 100% non-binding.",
     cta: {
-      A: "Secure Free Consultation",
-      B: "Start Free Now"
+      A: "Secure your free initial consultation now",
+      B: "Secure your free initial consultation now"
     },
-    calendar: "📅 Show available appointments",
-    urgency: "⏰ Only a few spots left for this week"
+    calendar: "📅 Select date here"
   }
 };
 
@@ -44,18 +42,9 @@ export const BOFUSection: React.FC<BOFUSectionProps> = ({ variant, language }) =
             {texts.title}
           </h2>
           
-          <p className="body-large mb-8 text-white/90 max-w-2xl mx-auto">
+          <p className="body-large mb-8 text-white/90 max-w-2xl mx-auto whitespace-pre-line">
             {texts.subtitle}
           </p>
-
-          {/* Urgency Indicator */}
-          <div className="mb-8">
-            <div className="inline-flex items-center bg-cta-accent/20 border border-cta-accent/30 rounded-full px-4 py-2">
-              <span className="text-cta-accent-light font-medium">
-                {texts.urgency}
-              </span>
-            </div>
-          </div>
 
           {/* CTAs */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-12">

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -6,36 +6,20 @@ interface FAQSectionProps {
 
 const faqContent = {
   de: {
-    title: "Häufige Fragen",
+    title: "Wichtig zu wissen",
     faqs: [
       {
-        question: "Ist das ein Schnell-Reich-Programm?",
-        answer: "Nein. Es ist ein strukturiertes Training. Ergebnisse brauchen Einsatz."
-      },
-      {
-        question: "Kann ich das nebenbei machen?",
-        answer: "Ja, das Programm ist so aufgebaut, dass es auch neben einem Job funktioniert."
-      },
-      {
-        question: "Was kostet der Einstieg?",
-        answer: "Das klären wir im kostenlosen Erstgespräch — ohne Verpflichtung."
+        question: "Was ist das für ein Coaching?",
+        answer: "Wir sind kein staatlich anerkanntes Fernstudium. Unser Coaching ist eine praxisorientierte Begleitung, die dir direkt im Alltag weiterhelfen soll. Es geht nicht um Titel oder Diplome – sondern darum, dass du echte Fähigkeiten entwickelst, die dir neue Chancen eröffnen."
       }
     ]
   },
   en: {
-    title: "Frequently Asked Questions",
+    title: "Important to know",
     faqs: [
       {
-        question: "Is this a get-rich-quick program?",
-        answer: "No. It's structured training. Results require commitment."
-      },
-      {
-        question: "Can I do this on the side?",
-        answer: "Yes, the program is designed to work alongside a job."
-      },
-      {
-        question: "What does entry cost?",
-        answer: "We'll clarify that in the free initial consultation — without obligation."
+        question: "What kind of coaching is this?",
+        answer: "We are not a state-recognized distance learning program. Our coaching is a practice-oriented support that is intended to help you directly in everyday life. It is not about titles or diplomas - but about developing real skills that open up new opportunities for you."
       }
     ]
   }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,7 +10,6 @@ const content = {
     company: "K2K Consulting UG",
     contact: "Kontakt",
     email: "info@k2k-consulting.de",
-    phone: "+49 (0) 421 123 456 789",
     address: "Süderbrokerstr 16, 28259 Bremen",
     legal: "Rechtliches",
     privacy: "Datenschutzerklärung",
@@ -24,7 +23,6 @@ const content = {
     company: "K2K Consulting UG", 
     contact: "Contact",
     email: "info@k2k-consulting.de",
-    phone: "+49 (0) 421 123 456 789",
     address: "Süderbrokerstr 16, 28259 Bremen",
     legal: "Legal",
     privacy: "Privacy Policy",
@@ -73,11 +71,6 @@ export const Footer: React.FC<FooterProps> = ({ language, onLanguageChange }) =>
               <p>
                 <a href={`mailto:${texts.email}`} className="hover:text-cta-accent transition-colors">
                   {texts.email}
-                </a>
-              </p>
-              <p>
-                <a href={`tel:${texts.phone.replace(/\s/g, '')}`} className="hover:text-cta-accent transition-colors">
-                  {texts.phone}
                 </a>
               </p>
               <p className="text-sm">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -12,15 +12,15 @@ interface HeroProps {
 const heroContent = {
   A: {
     de: {
-      headline: "Bist du bereit, dein 9–5 hinter dir zu lassen?",
-      subhead: "Lerne eine Fähigkeit, die dir neue Karrierechancen und echte Freiheit bringt – egal ob Zeit oder Ort.",
+      headline: "🚀 Dein Weg in eine erfolgreiche Karriere im Vertrieb",
+      subhead: "Stell dir vor: Du arbeitest Woche für Woche hart. 40 Stunden, manchmal mehr. Und trotzdem bleibt am Ende des Monats kaum etwas übrig. Keine Freiheit, keine Perspektive – nur das Gefühl, im Kreis zu laufen.",
       primaryCta: "Kostenloses Erstgespräch sichern",
       secondaryCta: "Mehr erfahren",
       videoCaption: "Neue Karrierewege entdecken"
     },
     en: {
-      headline: "Ready to leave your 9-5 behind?",
-      subhead: "Learn a skill that brings you new career opportunities and real freedom – regardless of time or place.",
+      headline: "🚀 Your Path to a Successful Career in Sales",
+      subhead: "Imagine working hard week after week. 40 hours, sometimes more. And yet, at the end of the month, there's hardly anything left. No freedom, no perspective – just the feeling of running in circles.",
       primaryCta: "Secure Free Consultation",
       secondaryCta: "Learn More",
       videoCaption: "Discover new career paths"
@@ -28,16 +28,16 @@ const heroContent = {
   },
   B: {
     de: {
-      headline: "Reicht es dir, für 1.500 € netto dein Leben zu verschwenden?",
-      subhead: "Es gibt einen Weg raus. Eine Fähigkeit, die dich aus dem Mindestlohn rausführt – und neue Türen öffnet.",
-      primaryCta: "Jetzt kostenlos starten",
+      headline: "🚀 Dein Weg in eine erfolgreiche Karriere im Vertrieb",
+      subhead: "Stell dir vor: Du arbeitest Woche für Woche hart. 40 Stunden, manchmal mehr. Und trotzdem bleibt am Ende des Monats kaum etwas übrig. Keine Freiheit, keine Perspektive – nur das Gefühl, im Kreis zu laufen.",
+      primaryCta: "Kostenloses Erstgespräch sichern",
       secondaryCta: "Mehr erfahren",
       videoCaption: "Weg aus dem Mindestlohn"
     },
     en: {
-      headline: "Tired of wasting your life for €1,500 net?",
-      subhead: "There's a way out. A skill that leads you out of low wages – and opens new doors.",
-      primaryCta: "Start Free Now",
+      headline: "🚀 Your Path to a Successful Career in Sales",
+      subhead: "Imagine working hard week after week. 40 hours, sometimes more. And yet, at the end of the month, there's hardly anything left. No freedom, no perspective – just the feeling of running in circles.",
+      primaryCta: "Secure Free Consultation",
       secondaryCta: "Learn More",
       videoCaption: "Escape low wages"
     }

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -6,36 +6,36 @@ interface HowItWorksSectionProps {
 
 const content = {
   de: {
-    title: "So funktioniert's",
+    title: "Dein möglicher Weg",
     steps: [
       {
-        title: "Kostenloses Erstgespräch sichern",
-        description: "In einem unverbindlichen Gespräch lernen wir uns kennen und besprechen deine Situation."
+        title: "Erstgespräch (kostenlos & unverbindlich)",
+        description: "Wir sprechen über deine aktuelle Situation und deine Ziele."
       },
       {
-        title: "Gemeinsam prüfen, ob das Modell zu dir passt",
-        description: "Wir schauen ehrlich, ob unser Programm zu deinen Zielen und deiner Lebenssituation passt."
+        title: "Entscheidung",
+        description: "Gemeinsam klären wir, ob und wie wir dich begleiten können."
       },
       {
-        title: "Skill lernen – und neue Chancen eröffnen",
-        description: "Mit strukturiertem Training und persönlicher Betreuung entwickelst du die Fähigkeiten für deine neue Zukunft."
+        title: "Begleitung starten",
+        description: "Du lernst Schritt für Schritt, wie Verkauf funktioniert – mit Praxis, Feedback und Austausch."
       }
     ]
   },
   en: {
-    title: "How It Works",
+    title: "Your Possible Path",
     steps: [
       {
-        title: "Secure Free Initial Consultation",
-        description: "In a non-binding conversation, we get to know each other and discuss your situation."
+        title: "Initial Consultation (free & non-binding)",
+        description: "We talk about your current situation and your goals."
       },
       {
-        title: "Together Check If The Model Fits You",
-        description: "We honestly look at whether our program fits your goals and life situation."
+        title: "Decision",
+        description: "Together we clarify if and how we can support you."
       },
       {
-        title: "Learn Skill – And Open New Opportunities",
-        description: "With structured training and personal support, you develop the skills for your new future."
+        title: "Start Coaching",
+        description: "You will learn step by step how sales works – with practice, feedback and exchange."
       }
     ]
   }

--- a/src/components/PainPointsSection.tsx
+++ b/src/components/PainPointsSection.tsx
@@ -9,37 +9,37 @@ const painContent = {
   A: {
     de: {
       points: [
-        "                                        40-50 Stunden arbeiten, nur um 1.500 € netto zu verdienen",
-        "                                        Kein Raum für deine eigenen Träume",
-        "                                        Abhängig vom Chef und seinen Launen"
+        "Du arbeitest Woche für Woche hart. 40 Stunden, manchmal mehr.",
+        "Und trotzdem bleibt am Ende des Monats kaum etwas übrig.",
+        "Keine Freiheit, keine Perspektive – nur das Gefühl, im Kreis zu laufen."
       ],
-      transition: "Es gibt einen anderen Weg – mit einem Skill, der gefragt ist und dir Kontrolle über deine Zukunft gibt."
+      transition: "Ich habe selbst erlebt, wie befreiend es ist, Verkaufen zu können. Es geht nicht nur ums Geld – es geht darum, zu wissen, dass man unabhängig ist. Dass man nicht mehr auf „Glück“ im Job hoffen muss, sondern einen Skill hat, der überall gebraucht wird."
     },
     en: {
       points: [
-        "Work 40–50 hours just to earn €1,500 net",
-        "No room for your own dreams",
-        "Dependent on your boss and their moods"
+        "You work hard week after week. 40 hours, sometimes more.",
+        "And yet, at the end of the month, there's hardly anything left.",
+        "No freedom, no perspective – just the feeling of running in circles."
       ],
-      transition: "There's another way – with a skill that's in demand and gives you control over your future."
+      transition: "I have experienced for myself how liberating it is to be able to sell. It's not just about money – it's about knowing that you are independent. That you no longer have to hope for 'luck' in your job, but have a skill that is needed everywhere."
     }
   },
   B: {
     de: {
       points: [
-        "40–50 Stunden Arbeit für einen Mindestlohn",
-        "Keine Perspektive, keine Freiheit",
-        "Frust statt Zukunft"
+        "Du arbeitest Woche für Woche hart. 40 Stunden, manchmal mehr.",
+        "Und trotzdem bleibt am Ende des Monats kaum etwas übrig.",
+        "Keine Freiheit, keine Perspektive – nur das Gefühl, im Kreis zu laufen."
       ],
-      transition: "Mit einem Skill kannst du sofort einen neuen Weg einschlagen – und dein Leben in Bewegung bringen."
+      transition: "Ich habe selbst erlebt, wie befreiend es ist, Verkaufen zu können. Es geht nicht nur ums Geld – es geht darum, zu wissen, dass man unabhängig ist. Dass man nicht mehr auf „Glück“ im Job hoffen muss, sondern einen Skill hat, der überall gebraucht wird."
     },
     en: {
       points: [
-        "40–50 hours of work for minimum wage",
-        "No perspective, no freedom",
-        "Frustration instead of future"
+        "You work hard week after week. 40 hours, sometimes more.",
+        "And yet, at the end of the month, there's hardly anything left.",
+        "No freedom, no perspective – just the feeling of running in circles."
       ],
-      transition: "With a skill you can immediately take a new path – and get your life moving."
+      transition: "I have experienced for myself how liberating it is to be able to sell. It's not just about money – it's about knowing that you are independent. That you no longer have to hope for 'luck' in your job, but have a skill that is needed everywhere."
     }
   }
 };

--- a/src/components/ProductDetailsSection.tsx
+++ b/src/components/ProductDetailsSection.tsx
@@ -7,106 +7,56 @@ interface ProductDetailsSectionProps {
 
 const content = {
   de: {
-    title: "Das Sales Coaching Programm",
-    subtitle: "Strukturiertes Training für deinen Erfolg im Vertrieb",
+    title: "Meine Mission",
+    subtitle: "Ich habe selbst erlebt, wie befreiend es ist, Verkaufen zu können. Es geht nicht nur ums Geld – es geht darum, zu wissen, dass man unabhängig ist. Dass man nicht mehr auf „Glück“ im Job hoffen muss, sondern einen Skill hat, der überall gebraucht wird. Heute begleite ich Menschen wie dich dabei, diese Fähigkeit Schritt für Schritt aufzubauen. Kein Frontalunterricht. Keine graue Theorie. Sondern echtes, praxisnahes Coaching, das sich an deinem Alltag orientiert.",
     features: [
       {
-        title: "Praxisorientierte Module",
-        description: "Lerne die wichtigsten Verkaufstechniken in strukturierten Einheiten, die du sofort anwenden kannst.",
-        icon: "📚"
+        title: "Persönliche Begleitung",
+        description: "Wir sprechen individuell über deine Situation und passen das Coaching darauf an.",
+        icon: "👉"
       },
       {
-        title: "1:1 Mentoring",
-        description: "Persönliche Betreuung durch erfahrene Sales-Profis, die dir bei deinen individuellen Herausforderungen helfen.",
-        icon: "👥"
+        title: "Praxisnah statt Theorie",
+        description: "Alles, was du lernst, kannst du sofort anwenden.",
+        icon: "👉"
       },
       {
-        title: "Flexibles Lernen",
-        description: "Online-Training, das sich deinem Zeitplan anpasst. Lerne wann und wo es für dich passt.",
-        icon: "⏰"
+        title: "Flexibel",
+        description: "Du entscheidest, wann und wo du lernst.",
+        icon: "👉"
       },
       {
-        title: "Praktische Tools",
-        description: "Bewährte Skripte, Templates und Techniken, die du direkt in deinem Job einsetzen kannst.",
-        icon: "🛠️"
-      },
-      {
-        title: "Community Support",
-        description: "Vernetze dich mit anderen Teilnehmern und profitiere vom Austausch mit Gleichgesinnten.",
-        icon: "🤝"
-      },
-      {
-        title: "Zertifizierung",
-        description: "Erhalte ein anerkanntes Zertifikat, das deine erworbenen Sales-Kompetenzen bestätigt.",
-        icon: "🏆"
+        title: "Community",
+        description: "Austausch mit Menschen, die den gleichen Weg gehen.",
+        icon: "👉"
       }
     ],
-    learningPath: {
-      title: "Dein Lernweg",
-      steps: [
-        "Grundlagen des professionellen Verkaufens",
-        "Kundenpsychologie und Bedarfsanalyse", 
-        "Gesprächsführung und Präsentationstechniken",
-        "Einwandbehandlung und Abschlusstechniken",
-        "Digitale Sales-Tools und CRM-Systeme",
-        "Langfristige Kundenbeziehungen aufbauen"
-      ]
-    },
-    guarantee: {
-      title: "Unsere Garantie",
-      text: "Falls du nach 30 Tagen nicht zufrieden bist, erhältst du dein Geld zurück. Wir sind überzeugt von der Qualität unseres Programms."
-    }
   },
   en: {
-    title: "The Sales Coaching Program",
-    subtitle: "Structured training for your success in sales",
+    title: "My Mission",
+    subtitle: "I have experienced for myself how liberating it is to be able to sell. It's not just about money – it's about knowing that you are independent. That you no longer have to hope for 'luck' in your job, but have a skill that is needed everywhere. Today, I support people like you in building this ability step by step. No lectures. No gray theory. But real, practical coaching that is geared to your everyday life.",
     features: [
       {
-        title: "Practice-Oriented Modules", 
-        description: "Learn the most important sales techniques in structured units that you can apply immediately.",
-        icon: "📚"
+        title: "Personal Support",
+        description: "We talk individually about your situation and adapt the coaching accordingly.",
+        icon: "👉"
       },
       {
-        title: "1:1 Mentoring",
-        description: "Personal support from experienced sales professionals who help you with your individual challenges.",
-        icon: "👥"
+        title: "Practical instead of theory",
+        description: "Everything you learn, you can apply immediately.",
+        icon: "👉"
       },
       {
-        title: "Flexible Learning",
-        description: "Online training that adapts to your schedule. Learn when and where it suits you.",
-        icon: "⏰"
+        title: "Flexible",
+        description: "You decide when and where you learn.",
+        icon: "👉"
       },
       {
-        title: "Practical Tools",
-        description: "Proven scripts, templates and techniques that you can use directly in your job.",
-        icon: "🛠️"
-      },
-      {
-        title: "Community Support",
-        description: "Network with other participants and benefit from exchange with like-minded people.",
-        icon: "🤝"
-      },
-      {
-        title: "Certification",
-        description: "Receive a recognized certificate that confirms your acquired sales skills.",
-        icon: "🏆"
+        title: "Community",
+        description: "Exchange with people who are on the same path.",
+        icon: "👉"
       }
-    ],
-    learningPath: {
-      title: "Your Learning Path",
-      steps: [
-        "Fundamentals of professional selling",
-        "Customer psychology and needs analysis",
-        "Conversation management and presentation techniques", 
-        "Objection handling and closing techniques",
-        "Digital sales tools and CRM systems",
-        "Building long-term customer relationships"
-      ]
-    },
-    guarantee: {
-      title: "Our Guarantee",
-      text: "If you're not satisfied after 30 days, you get your money back. We are convinced of the quality of our program."
-    }
+    ]
   }
 };
 
@@ -135,7 +85,7 @@ export const ProductDetailsSection: React.FC<ProductDetailsSectionProps> = ({ la
           </div>
 
           {/* Features Grid */}
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
+          <div className="grid md:grid-cols-2 gap-8 mb-16">
             {texts.features.map((feature, index) => (
               <div key={index} className="bg-white rounded-xl p-6 shadow-sm border border-neutral-200">
                 <div className="text-3xl mb-4">{feature.icon}</div>
@@ -147,35 +97,6 @@ export const ProductDetailsSection: React.FC<ProductDetailsSectionProps> = ({ la
                 </p>
               </div>
             ))}
-          </div>
-
-          {/* Learning Path */}
-          <div className="bg-white rounded-2xl p-8 md:p-12 shadow-sm border border-neutral-200 mb-12">
-            <h3 className="text-2xl font-bold mb-8 text-center text-neutral-900">
-              {texts.learningPath.title}
-            </h3>
-            <div className="grid md:grid-cols-2 gap-4">
-              {texts.learningPath.steps.map((step, index) => (
-                <div key={index} className="flex items-start gap-3">
-                  <div className="w-8 h-8 bg-trust-primary text-white rounded-full flex items-center justify-center flex-shrink-0 text-sm font-bold">
-                    {index + 1}
-                  </div>
-                  <p className="text-neutral-700 leading-relaxed">
-                    {step}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Guarantee */}
-          <div className="bg-gradient-to-r from-trust-primary/5 to-cta-accent/5 rounded-2xl p-8 text-center border border-trust-primary/20">
-            <h3 className="text-xl font-bold mb-4 text-trust-primary">
-              {texts.guarantee.title}
-            </h3>
-            <p className="text-neutral-700 max-w-2xl mx-auto">
-              {texts.guarantee.text}
-            </p>
           </div>
         </div>
       </div>

--- a/src/components/SocialProofStrip.tsx
+++ b/src/components/SocialProofStrip.tsx
@@ -8,44 +8,42 @@ interface SocialProofStripProps {
 
 const content = {
   de: {
-    main: "Bereits über 200 junge Menschen in Deutschland, Österreich und der Schweiz haben durch professionelle Sales-Skills neue Karrierewege eingeschlagen.",
+    main: "Stimmen aus dem Coaching",
     testimonials: [
       {
-        text: "Nach dem Sales Training konnte ich innerhalb von 6 Monaten mein Einkommen um 40% steigern und arbeite jetzt in einem Bereich, der mir wirklich Spaß macht.",
+        text: "Ich hätte nie gedacht, dass ich mal gerne im Vertrieb arbeite. Nach dem Coaching habe ich mein Einkommen in 6 Monaten um 40 % gesteigert – und das ohne Vorerfahrung.",
         name: "Sarah M.",
         location: "München",
         role: "Account Managerin",
         image: sarahImg
       },
       {
-        text: "Das strukturierte Sales Coaching hat mir geholfen, aus der Arbeitslosigkeit herauszufinden und eine Position im Vertrieb zu bekommen, wo ich meine Stärken nutzen kann.",
+        text: "Vorher war ich arbeitslos. Heute habe ich einen Job im Vertrieb, der mir wirklich liegt. Das Coaching hat mir Struktur gegeben und gezeigt, wie ich meine Stärken einsetzen kann.",
         name: "Marcus L.",
         location: "Hamburg", 
         role: "Sales Representative",
         image: marcusImg
       }
-    ],
-    disclaimer: "Individuelle Ergebnisse können variieren. Erfolg erfordert Einsatz und kontinuierliches Lernen."
+    ]
   },
   en: {
-    main: "Over 200 young people in Germany, Austria and Switzerland have already embarked on new career paths through professional sales skills.",
+    main: "Voices from the Coaching",
     testimonials: [
       {
-        text: "After the sales training, I was able to increase my income by 40% within 6 months and now work in a field that I really enjoy.",
+        text: "I never thought I would enjoy working in sales. After the coaching, I increased my income by 40% in 6 months – with no prior experience.",
         name: "Sarah M.",
         location: "Munich",
         role: "Account Manager",
         image: sarahImg
       },
       {
-        text: "The structured sales coaching helped me get out of unemployment and get a position in sales where I can use my strengths.",
+        text: "Before, I was unemployed. Today I have a job in sales that I really like. The coaching gave me structure and showed me how to use my strengths.",
         name: "Marcus L.",
         location: "Hamburg",
         role: "Sales Representative", 
         image: marcusImg
       }
-    ],
-    disclaimer: "Individual results may vary. Success requires effort and continuous learning."
+    ]
   }
 };
 
@@ -57,9 +55,9 @@ export const SocialProofStrip: React.FC<SocialProofStripProps> = ({ language }) 
       <div className="container mx-auto px-4">
         <div className="text-center max-w-5xl mx-auto">
           {/* Main Social Proof Statement */}
-          <p className="body-large mb-12 font-semibold text-neutral-700">
+          <h2 className="section-headline mb-12 text-neutral-900">
             {texts.main}
-          </p>
+          </h2>
 
           {/* Testimonials Grid */}
           <div className="grid md:grid-cols-2 gap-8 mb-12">
@@ -77,20 +75,12 @@ export const SocialProofStrip: React.FC<SocialProofStripProps> = ({ language }) 
                     "{testimonial.text}"
                   </blockquote>
                   <cite className="font-semibold text-trust-primary">
-                    — {testimonial.name}
+                    — {testimonial.name}, {testimonial.location}
                   </cite>
-                  <p className="text-sm text-neutral-500">
-                    {testimonial.role} • {testimonial.location}
-                  </p>
                 </div>
               </div>
             ))}
           </div>
-
-          {/* Disclaimer */}
-          <p className="body-small text-neutral-500 italic max-w-2xl mx-auto">
-            {texts.disclaimer}
-          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Updates the website copy to the new German text provided by the user.

- Unifies the messaging for both A/B test variants.
- Updates all sections: Hero, Pain Points, Product Details, Testimonials, How It Works, FAQ, and the final CTA.
- Removes the phone number from the footer.
- Adds corresponding English translations for the new copy.