### PR TITLE
feat: Add vercel.json to handle client-side routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This commit introduces a `vercel.json` file with a rewrite rule to redirect all requests to `index.html`. This is necessary for single-page applications (SPAs) hosted on Vercel to handle client-side routing correctly and prevent 404 errors when accessing pages directly.